### PR TITLE
feat(chat): add chat UI components with typing indicator and auto-scroll

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -4,12 +4,3 @@
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
-
-html,
-body {
-  @apply bg-white dark:bg-gray-950;
-
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-  }
-}

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -2,13 +2,14 @@ import React, { useState, useRef, useEffect } from "react";
 
 type Props = {
   onSend: (message: string) => void;
+  botIsTyping: boolean;
 };
 
-export const ChatInput = ({ onSend }: Props) => {
+export const ChatInput = ({ onSend, botIsTyping }: Props) => {
   const [message, setMessage] = useState("");
 
   const handleSubmit = () => {
-    if (!message.trim()) return;
+    if (!message.trim() || botIsTyping) return;
     onSend(message.trim()); // send the message up
     setMessage(""); // reset the input
   };
@@ -33,7 +34,7 @@ export const ChatInput = ({ onSend }: Props) => {
         <button
           onClick={handleSubmit}
           className="ml-2 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
-          disabled={!message.trim()}
+          disabled={!message.trim() || botIsTyping}
         >
           Send
         </button>

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -1,0 +1,43 @@
+import React, { useState, useRef, useEffect } from "react";
+
+type Props = {
+  onSend: (message: string) => void;
+};
+
+export const ChatInput = ({ onSend }: Props) => {
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = () => {
+    if (!message.trim()) return;
+    onSend(message.trim()); // send the message up
+    setMessage(""); // reset the input
+  };
+
+  const handleEnterKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault(); // Prevent newline
+      handleSubmit(); // Send message
+    }
+  };
+  return (
+    <div className="w-full fixed bottom-4 max-w-2xl mx-auto p-4">
+      <div className="flex border rounded-lg p-2 bg-white shadow-md">
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          onKeyDown={handleEnterKeyDown}
+          rows={1}
+          placeholder="Ask a dietitian..."
+          className="flex-1 resize-none overflow-hidden outline-none bg-transparent text-base max-h-48"
+        />
+        <button
+          onClick={handleSubmit}
+          className="ml-2 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+          disabled={!message.trim()}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -21,7 +21,7 @@ export const ChatInput = ({ onSend, botIsTyping }: Props) => {
     }
   };
   return (
-    <div className="w-full fixed bottom-4 max-w-2xl mx-auto p-4">
+    <div className="w-full fixed bottom-4 max-w-2xl mx-auto pb-4 left-1/2 transform -translate-x-1/2">
       <div className="flex border rounded-lg p-2 bg-white shadow-md">
         <textarea
           value={message}

--- a/app/components/ChatWindow.tsx
+++ b/app/components/ChatWindow.tsx
@@ -40,7 +40,7 @@ export const ChatWindow = () => {
       <div className="flex-1 pt-16 flex justify-center">
         <div className="w-full max-w-2xl px-4 flex flex-col">
           <MessageContainer messages={messages} botIsTyping={botIsTyping} />
-          <ChatInput onSend={onSend} />
+          <ChatInput onSend={onSend} botIsTyping={botIsTyping} />
         </div>
       </div>
     </div>

--- a/app/components/ChatWindow.tsx
+++ b/app/components/ChatWindow.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import { HeaderBar } from "~/components/HeaderBar";
+import { MessageContainer } from "./MessageContainer";
+import type { Message } from "~/types/message";
+import { ChatInput } from "./ChatInput";
+
+export const ChatWindow = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [botIsTyping, setBotIsTyping] = useState(false);
+
+  const onSend = async (message: string) => {
+    const newMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: message,
+    };
+    setMessages((prev: Message[]) => [...prev, newMessage]);
+
+    setBotIsTyping(true);
+    const botReply = await fakeBotReply(message);
+    setBotIsTyping(false);
+
+    const replyMessage = {
+      id: crypto.randomUUID(),
+      role: "bot",
+      content: botReply,
+    };
+
+    setMessages((prev: Message[]) => [...prev, replyMessage]);
+  };
+
+  const fakeBotReply = async (input: string) => {
+    await new Promise((res) => setTimeout(res, 1500)); // delay
+    return `Bot response to: "${input}"`;
+  };
+
+  return (
+    <div className="flex overflow-y-auto justify-center shadow-inner min-h-screen">
+      <HeaderBar />
+      <div className="flex-1 pt-16 flex justify-center">
+        <div className="w-full max-w-2xl px-4 flex flex-col">
+          <MessageContainer messages={messages} botIsTyping={botIsTyping} />
+          <ChatInput onSend={onSend} />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/components/HeaderBar.tsx
+++ b/app/components/HeaderBar.tsx
@@ -1,0 +1,9 @@
+export const HeaderBar = () => {
+  return (
+    <div className="fixed w-full z-50 flex flex-col p-2 shadow-sm">
+      <div>
+        <h2>Ask A Dietician</h2>
+      </div>
+    </div>
+  );
+};

--- a/app/components/MessageContainer.tsx
+++ b/app/components/MessageContainer.tsx
@@ -14,7 +14,7 @@ export const MessageContainer = ({
   }, [messages]);
 
   return (
-    <div className="flex-1 overflow-y-auto space-y-2 mb-4 p-2 pb-32 bg-white rounded shadow">
+    <div className="flex-1 overflow-y-auto space-y-2 pb-32 bg-white rounded shadow">
       {messages.map((msg) => (
         <div
           key={msg.id}

--- a/app/components/MessageContainer.tsx
+++ b/app/components/MessageContainer.tsx
@@ -1,0 +1,43 @@
+import type { Message } from "~/types/message";
+import { useRef, useEffect } from "react";
+export const MessageContainer = ({
+  messages,
+  botIsTyping,
+}: {
+  messages: Message[];
+  botIsTyping: boolean;
+}) => {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  return (
+    <div className="flex-1 overflow-y-auto space-y-2 mb-4 p-2 pb-32 bg-white rounded shadow">
+      {messages.map((msg) => (
+        <div
+          key={msg.id}
+          className={`p-2 rounded break-words ${
+            msg.role === "user"
+              ? "bg-blue-200 self-end max-w-xs text-right ml-auto "
+              : "self-start text-left mr-auto"
+          }`}
+        >
+          {msg.content}
+        </div>
+      ))}
+      {botIsTyping && (
+        <div className="p-2 rounded self-start text-left mr-auto">
+          <div className="inline-flex gap-1">
+            <span className="animate-bounce">.</span>
+            <span className="animate-bounce delay-150">.</span>
+            <span className="animate-bounce delay-300">.</span>
+          </div>
+        </div>
+      )}
+
+      <div ref={bottomRef} />
+    </div>
+  );
+};

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,5 +1,6 @@
 import type { Route } from "./+types/home";
 import { Welcome } from "../welcome/welcome";
+import { ChatWindow } from "~/components/ChatWindow";
 
 export function meta({}: Route.MetaArgs) {
   return [
@@ -13,5 +14,5 @@ export function loader({ context }: Route.LoaderArgs) {
 }
 
 export default function Home({ loaderData }: Route.ComponentProps) {
-  return <Welcome message={loaderData.message} />;
+  return <ChatWindow />;
 }

--- a/app/types/message.ts
+++ b/app/types/message.ts
@@ -1,0 +1,7 @@
+export type Role = "user" | "bot";
+
+export type Message = {
+  id: number;
+  role: Role;
+  content: string;
+};

--- a/app/welcome/welcome.tsx
+++ b/app/welcome/welcome.tsx
@@ -1,5 +1,6 @@
 import logoDark from "./logo-dark.svg";
 import logoLight from "./logo-light.svg";
+import React from "react";
 
 export function Welcome({ message }: { message: string }) {
   return (


### PR DESCRIPTION
- Created ChatInput, ChatWindow, MessageContainer, and HeaderBar components
- Implemented basic chat flow with user message input and fake bot reply
- Added typing animation when bot is responding
- Enabled auto-scroll to bottom on new messages
- Replaced Welcome screen with ChatWindow in home route
- Moved message types to `~/types/message.ts`
- Removed dark mode background styles from global CSS

![AI Chatbot](https://github.com/user-attachments/assets/3d3974fe-4ef0-46b5-941a-9f36eefb7063)


For Issue #5 
 